### PR TITLE
fix(copy-markdown-button-margin): copy markdown button margin (#35)

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,5 +1,5 @@
---- 
---- 
+---
+---
 @import "monkai.css";
 @import "./colors";
 
@@ -159,8 +159,8 @@ html {
 
           .copy-markdown-button {
             position: absolute;
-            margin-right: 1rem;
-            margin-top: 1rem;
+            margin-right: .2rem;
+            margin-top: .2rem;
           }
         }
       }


### PR DESCRIPTION
closes #35 